### PR TITLE
Restrict usage of the ResourceAttribute to classes only since it is only found via HandlerType

### DIFF
--- a/src/Swank/Description/ResourceAttribute.cs
+++ b/src/Swank/Description/ResourceAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace FubuMVC.Swank.Description
 {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class ResourceAttribute : Attribute
     {
         public ResourceAttribute(string name, string comments = null)


### PR DESCRIPTION
This will prevent accidental usage on controller method.
